### PR TITLE
Rework json build

### DIFF
--- a/src/main/kotlin/reporter/JsonReporter.kt
+++ b/src/main/kotlin/reporter/JsonReporter.kt
@@ -27,8 +27,7 @@ class JsonReporter(private val out: PrintStream) : Reporter {
             for ((index, err) in errList.withIndex()) {
                 val (line, _, ruleId, detail) = err
 
-                val name = (file.split("/").last().split(".").takeIf { it.size == 2 }?.firstOrNull()
-                    ?.takeIf { it.isNotBlank() }?.let { "$it:$line - $detail" } ?: detail)
+                val name = "${File(file).nameWithoutExtension}:$line - $detail"
 
                 val rootPath = Paths.get("").toAbsolutePath()
                 val filePath = File(file).toPath()


### PR DESCRIPTION
I noticed that the "," after some entries were missing if there are lint errors in multiple files.

I rewrote the code to use `joinToString` to join the elements which  makes it easier to read imo.
I also simplified the code to extract the filename.